### PR TITLE
fix: yarn audit

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     ]
   },
   "scripts": {
-    "audit": "node scripts/audit.js dependencies moderate",
+    "audit": "node scripts/audit.js '--environment production' moderate",
     "build": "run-s -s 'build:*' storybook:build:storybook",
     "build:packages": "yarn run-all --include-dependencies build",
     "ci-check": "run-s -s 'ci-check:*' storybook:build",

--- a/scripts/audit.js
+++ b/scripts/audit.js
@@ -18,7 +18,7 @@ let auditLevel;
 
 async function audit() {
   auditLevel = level ? ' --level ' + level : '';
-  const auditCommand = 'yarn npm audit --groups ' + group + auditLevel;
+  const auditCommand = 'yarn npm audit ' + group + auditLevel;
   console.log('Running audit using:', auditCommand);
   await exec(auditCommand);
 }


### PR DESCRIPTION
Contributes to #

`--groups` seems to be deprecated in yarn berry.
Tried to find equivalent command for yarn 2+.
https://yarnpkg.com/cli/npm/audit

#### What did you change?
Update audit command to work with current version of yarn.

#### How did you test and verify your work?
`yarn ci-check:lint` does not hang.